### PR TITLE
Updated image import from pillow, for use with modern pillow versions

### DIFF
--- a/ui/graphics_class.py
+++ b/ui/graphics_class.py
@@ -1,5 +1,5 @@
 from PyQt5 import QtWidgets, QtGui, QtCore
-from PIL.ImageQt import ImageQt
+from PIL.ImageQt import Image as ImageQt
 
 
 class ImageItem(QtWidgets.QGraphicsObject):

--- a/ui/tree_view_classes.py
+++ b/ui/tree_view_classes.py
@@ -4,7 +4,7 @@ import core_files.statusbar as sts
 
 from core_files import core
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PIL.ImageQt import ImageQt
+from PIL.ImageQt import Image as ImageQt
 
 log = sts.get_logger(__name__)
 


### PR DESCRIPTION
Pillow is currently on version 11.1.0, and I get this error when trying to run your program:
```
python .\OWM.py
Traceback (most recent call last):
  File "C:\Users\jmynes\Downloads\OWM-Qt-2.1.0\OWM.py", line 3, in <module>
    from ui.main_window import MyApp
  File "C:\Users\jmynes\Downloads\OWM-Qt-2.1.0\ui\main_window.py", line 18, in <module>
    from ui.graphics_class import ImageItem
  File "C:\Users\jmynes\Downloads\OWM-Qt-2.1.0\ui\graphics_class.py", line 2, in <module>
    from PIL.ImageQt import ImageQt
ImportError: cannot import name 'ImageQt' from 'PIL.ImageQt' (C:\Users\jmynes\AppData\Roaming\Python\Python312\site-packages\PIL\ImageQt.py). Did you mean: 'Image'?
```

This PR should fix the issue!

Tested on Windows 10 x64 with up to date PyQt5, pillow, pip, and python3, as of Feb 1st, 2025